### PR TITLE
Fix references to nonexistent members in bounds methods.

### DIFF
--- a/textgrid.py
+++ b/textgrid.py
@@ -204,7 +204,7 @@ class Interval(object):
             return self.minTime <= other <= self.maxTime
 
     def bounds(self):
-        return (self.minTime, self.maxTime or self.points[-1].maxTime)
+        return (self.minTime, self.maxTime)
 
 
 class PointTier(object):
@@ -313,7 +313,7 @@ class PointTier(object):
         sink.close()
 
     def bounds(self):
-        return (self.minTime, self.maxTime or self.intervals[-1].maxTime)
+        return (self.minTime, self.maxTime or self.points[-1].time)
 
 
 class PointTierFromFile(PointTier):


### PR DESCRIPTION
A possible extension to clean this up a little more might be to make the `PointTier` bounds return `(min(self), max(self))` and change the `__max__` to be `self.maxTime or self.points[-1].time`. But this PR fixes the crash without changing the functionality of max.
