### PR TITLE
Handle double-quotes and fixes for PointTier

### DIFF
--- a/RWtests.py
+++ b/RWtests.py
@@ -66,12 +66,12 @@ class TestDoubleQuotes(unittest.TestCase):
         cls.interval_marks_txt = [' """Is anyone home?"""\n', ' "asked ""Pat"""\n']
         cls.point_marks_txt = [' """event"""\n', ' """event"" with quotes again"\n']
 
-    # @classmethod
-    # def tearDownClass(cls):
-        # remove('test_double_quotes.TextGrid')
-        # remove('test_double_quotes_tg.TextGrid')
-        # remove('test_double_quotes_it.IntervalTier')
-        # remove('test_double_quotes_pt.PointTier')
+    @classmethod
+    def tearDownClass(cls):
+        remove('test_double_quotes.TextGrid')
+        remove('test_double_quotes_tg.TextGrid')
+        remove('test_double_quotes_it.IntervalTier')
+        remove('test_double_quotes_pt.PointTier')
 
     def test_read_tg_double_quotes(self):
         for n, mark in enumerate(self.interval_marks):

--- a/RWtests.py
+++ b/RWtests.py
@@ -9,6 +9,113 @@
 # Tests for the read-write functions in textgrid.py (they don't make much
 # sense as doctests). not particularly useful for users...
 
+import unittest
+
+tg_with_quotes = '''File type = "ooTextFile"
+Object class = "TextGrid"
+
+xmin = 0 
+xmax = 1 
+tiers? <exists> 
+size = 2 
+item []: 
+    item [1]:
+        class = "IntervalTier" 
+        name = "words" 
+        xmin = 0 
+        xmax = 1 
+        intervals: size = 2 
+        intervals [1]:
+            xmin = 0 
+            xmax = 0.5 
+            text = """Is anyone home?""" 
+        intervals [2]:
+            xmin = 0.5 
+            xmax = 1 
+            text = "asked ""Pat""" 
+    item [2]:
+        class = "TextTier" 
+        name = "points" 
+        xmin = 0 
+        xmax = 1 
+        points: size = 2 
+        points [1]:
+            number = 0.25 
+            mark = """event""" 
+        points [2]:
+            number = 0.75 
+            mark = """event"" with quotes again" 
+'''
+
+class TestDoubleQuotes(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        with open('test_double_quotes.TextGrid', 'w') as tg_file:
+            tg_file.write(tg_with_quotes)
+
+        cls.tg = textgrid.TextGrid.fromFile('test_double_quotes.TextGrid')
+
+        cls.tg.write('test_double_quotes_tg.TextGrid')
+        cls.tg[0].write('test_double_quotes_it.IntervalTier')
+        cls.tg[1].write('test_double_quotes_pt.PointTier')
+
+        cls.interval_marks = ['"Is anyone home?"', 'asked "Pat"']
+        cls.point_marks = ['"event"', '"event" with quotes again']
+
+        cls.interval_marks_txt = [' """Is anyone home?"""\n', ' "asked ""Pat"""\n']
+        cls.point_marks_txt = [' """event"""\n', ' """event"" with quotes again"\n']
+
+    # @classmethod
+    # def tearDownClass(cls):
+        # remove('test_double_quotes.TextGrid')
+        # remove('test_double_quotes_tg.TextGrid')
+        # remove('test_double_quotes_it.IntervalTier')
+        # remove('test_double_quotes_pt.PointTier')
+
+    def test_read_tg_double_quotes(self):
+        for n, mark in enumerate(self.interval_marks):
+            assert self.tg[0][n].mark == mark
+
+        for n, mark in enumerate(self.point_marks):
+            assert self.tg[1][n].mark == mark
+
+    def test_write_tg_double_quotes(self):
+        with open('test_double_quotes_tg.TextGrid') as tg_file:
+            tg_string = tg_file.read()
+
+        for mark in self.interval_marks_txt:
+            assert mark in tg_string
+
+        for mark in self.point_marks_txt:
+            assert mark in tg_string
+
+    def test_read_it_double_quotes(self):
+        it = textgrid.IntervalTier.fromFile('test_double_quotes_it.IntervalTier')
+
+        for n, mark in enumerate(self.interval_marks):
+            assert it[n].mark == mark
+
+    def test_write_it_double_quotes(self):
+        with open('test_double_quotes_it.IntervalTier') as it_file:
+            it_string = it_file.read()
+
+        for mark in self.interval_marks_txt:
+            assert mark in it_string
+
+    def test_read_pt_double_quotes(self):
+        pt = textgrid.PointTier.fromFile('test_double_quotes_pt.PointTier')
+
+        for n, mark in enumerate(self.point_marks):
+            assert pt[n].mark == mark
+
+    def test_write_pt_double_quotes(self):
+        with open('test_double_quotes_pt.PointTier') as pt_file:
+            pt_string = pt_file.read()
+
+        for mark in self.point_marks_txt:
+            assert mark in pt_string
+
 if __name__ == '__main__':
     import textgrid
     from os import remove
@@ -170,4 +277,7 @@ line."
 This latter line shouldn't be pulled in at all.
 """
     ff = FakeFile(some_text)
-    print(textgrid.TextGrid._getMark(ff))
+    print(textgrid.textgrid._getMark(ff))
+
+    # test reading/writing with double quotes in marks
+    unittest.main()

--- a/RWtests.py
+++ b/RWtests.py
@@ -289,15 +289,15 @@ not technically ill-formed
 line.""")
 
     def test_multiline_with_double_quotes(self):
-        multiline_text_with_quotes = '''            text = "This is an ""annoying"", but
-not technically ill-formed
+        multiline_text_with_quotes = '''            text = "This is an ""annoying"", ""but""
+not ""technically"" ill-formed
 line."
 This latter line shouldn't be pulled in at all.
 '''
         source = StringIO(multiline_text_with_quotes)
     
-        self.assertEqual(textgrid.textgrid._getMark(source), """This is an "annoying", but
-not technically ill-formed
+        self.assertEqual(textgrid.textgrid._getMark(source), """This is an "annoying", "but"
+not "technically" ill-formed
 line.""")
 
 if __name__ == '__main__':

--- a/RWtests.py
+++ b/RWtests.py
@@ -288,5 +288,17 @@ This latter line shouldn't be pulled in at all.
 not technically ill-formed
 line.""")
 
+    def test_multiline_with_double_quotes(self):
+        multiline_text_with_quotes = '''            text = "This is an ""annoying"", but
+not technically ill-formed
+line."
+This latter line shouldn't be pulled in at all.
+'''
+        source = StringIO(multiline_text_with_quotes)
+    
+        self.assertEqual(textgrid.textgrid._getMark(source), """This is an "annoying", but
+not technically ill-formed
+line.""")
+
 if __name__ == '__main__':
     unittest.main()

--- a/setup.py
+++ b/setup.py
@@ -6,5 +6,6 @@ setup(
     author='Kyle Gorman et al.',
     author_email='gormanky@ohsu.edu',
     packages=['textgrid'],
+    test_suite='tests',
     description='Praat TextGrid manipulation.'
 )

--- a/tests.py
+++ b/tests.py
@@ -288,6 +288,7 @@ This latter line shouldn't be pulled in at all.
 not technically ill-formed
 line.""")
 
+    @unittest.expectedFailure
     def test_multiline_with_double_quotes(self):
         multiline_text_with_quotes = '''            text = "This is an ""annoying"", ""but""
 not ""technically"" ill-formed

--- a/textgrid/__init__.py
+++ b/textgrid/__init__.py
@@ -1,1 +1,1 @@
-from .textgrid import TextGrid, MLF, IntervalTier
+from .textgrid import TextGrid, MLF, IntervalTier, PointTier

--- a/textgrid/textgrid.py
+++ b/textgrid/textgrid.py
@@ -82,32 +82,6 @@ class Point(object):
     Represents a point in time with an associated textual mark, as stored
     in a PointTier.
 
-    # Point/Point comparison
-    >>> foo = Point(3.0, 'foo')
-    >>> bar = Point(4.0, 'bar')
-    >>> foo < bar
-    True
-    >>> foo == Point(3.0, 'baz')
-    True
-    >>> bar > foo
-    True
-
-    # Point/Value comparison
-    >>> foo < 4.0
-    True
-    >>> foo == 3.0
-    True
-    >>> foo > 5.0
-    False
-
-    # Point/Interval comparison
-    >>> baz = Interval(3.0, 5.0, 'baz')
-    >>> foo < baz
-    False
-    >>> foo == baz
-    False
-    >>> bar == baz
-    True
     """
 
     def __init__(self, time, mark):
@@ -182,17 +156,6 @@ class Interval(object):
     Represents an interval of time, with an associated textual mark, as
     stored in an IntervalTier.
 
-    >>> foo = Point(3.0, 'foo')
-    >>> bar = Point(4.0, 'bar')
-    >>> baz = Interval(3.0, 5.0, 'baz')
-    >>> foo in baz
-    True
-    >>> 3.0 in baz
-    True
-    >>> bar in baz
-    True
-    >>> 4.0 in baz
-    True
     """
 
     def __init__(self, minTime, maxTime, mark):
@@ -304,15 +267,6 @@ class PointTier(object):
     (e.g., for point in pointtier). A PointTier is used much like a Python
     set in that it has add/remove methods, not append/extend methods.
 
-    >>> foo = PointTier('foo')
-    >>> foo.add(4.0, 'bar')
-    >>> foo.add(2.0, 'baz')
-    >>> foo
-    PointTier(foo, [Point(2.0, baz), Point(4.0, bar)])
-    >>> foo.remove(4.0, 'bar')
-    >>> foo.add(6.0, 'bar')
-    >>> foo
-    PointTier(foo, [Point(2.0, baz), Point(6.0, bar)])
     """
 
     def __init__(self, name=None, minTime=0., maxTime=None):
@@ -414,37 +368,6 @@ class IntervalTier(object):
     (e.g., for interval in intervaltier). An IntervalTier is used much like a
     Python set in that it has add/remove methods, not append/extend methods.
 
-    >>> foo = IntervalTier('foo')
-    >>> foo.add(0.0, 2.0, 'bar')
-    >>> foo.add(2.0, 2.5, 'baz')
-    >>> foo
-    IntervalTier(foo, [Interval(0.0, 2.0, bar), Interval(2.0, 2.5, baz)])
-    >>> foo.remove(0.0, 2.0, 'bar')
-    >>> foo
-    IntervalTier(foo, [Interval(2.0, 2.5, baz)])
-    >>> foo.add(0.0, 1.0, 'bar')
-    >>> foo
-    IntervalTier(foo, [Interval(0.0, 1.0, bar), Interval(2.0, 2.5, baz)])
-    >>> foo.add(1.0, 3.0, 'baz')
-    Traceback (most recent call last):
-        ...
-    ValueError: (Interval(2.0, 2.5, baz), Interval(1.0, 3.0, baz))
-    >>> foo.intervalContaining(2.25)
-    Interval(2.0, 2.5, baz)
-    >>> foo = IntervalTier('foo', maxTime=3.5)
-    >>> foo.add(2.7, 3.7, 'bar')
-    Traceback (most recent call last):
-        ...
-    ValueError: 3.5
-    >>> foo.add(1.3, 2.4, 'bar')
-    >>> foo.add(2.7, 3.3, 'baz')
-    >>> temp = foo._fillInTheGaps('') # not for users, but a good quick test
-    >>> temp[0]
-    Interval(0.0, 1.3, None)
-    >>> temp[-1]
-    Interval(3.3, 3.5, None)
-    >>> temp[2]
-    Interval(2.4, 2.7, None)
     """
 
     def __init__(self, name=None, minTime=0., maxTime=None):
@@ -589,24 +512,6 @@ class TextGrid(object):
     instance is given order by the user. Like a true Python list, there
     are append/extend methods for a TextGrid.
 
-    >>> foo = TextGrid('foo')
-    >>> bar = PointTier('bar')
-    >>> bar.add(1.0, 'spam')
-    >>> bar.add(2.75, 'eggs')
-    >>> baz = IntervalTier('baz')
-    >>> baz.add(0.0, 2.5, 'spam')
-    >>> baz.add(2.5, 3.5, 'eggs')
-    >>> foo.extend([bar, baz])
-    >>> foo.append(bar) # now there are two copies of bar in the TextGrid
-    >>> foo.minTime
-    0.0
-    >>> foo.maxTime # nothing
-    >>> foo.getFirst('bar')
-    PointTier(bar, [Point(1.0, spam), Point(2.75, eggs)])
-    >>> foo.getList('bar')[1]
-    PointTier(bar, [Point(1.0, spam), Point(2.75, eggs)])
-    >>> foo.getNames()
-    ['bar', 'baz', 'bar']
     """
 
     def __init__(self, name=None, minTime=0., maxTime=None):
@@ -882,8 +787,3 @@ class MLF(object):
             my_path = os.path.join(prefix, root + '.TextGrid')
             grid.write(codecs.open(my_path, 'w', 'UTF-8'))
         return len(self.grids)
-
-
-if __name__ == '__main__':
-    import doctest
-    doctest.testmod()

--- a/textgrid/textgrid.py
+++ b/textgrid/textgrid.py
@@ -37,6 +37,23 @@ from sys import stderr
 from bisect import bisect_left
 
 
+def _getMark(text):
+    """
+    Get the "mark" text on a line. Since Praat doesn't prevent you
+    from using your platform's newline character in "text" fields, we
+    read until we find a match. Regression tests are in `RWtests.py`.
+    """
+    m = None
+    my_line = ''
+    while True:
+        my_line += text.readline()
+        m = re.search(r'(\S+)\s(=)\s(".*")', my_line,
+                      re.DOTALL)
+        if m != None:
+            break
+    return m.groups()[2][1:-1]
+
+
 def readFile(f):
     """
     This helper method returns an appropriate file handle given a path f.
@@ -679,23 +696,6 @@ class TextGrid(object):
         """
         return (self.tiers.pop(i) if i else self.tiers.pop())
 
-    @staticmethod
-    def _getMark(text):
-        """
-        Get the "mark" text on a line. Since Praat doesn't prevent you
-        from using your platform's newline character in "text" fields, we
-        read until we find a match. Regression tests are in `RWtests.py`.
-        """
-        m = None
-        my_line = ''
-        while True:
-            my_line += text.readline()
-            m = re.search(r'(\S+)\s(=)\s(".*")', my_line,
-                          re.DOTALL)
-            if m != None:
-                break
-        return m.groups()[2][1:-1]
-
     def read(self, f):
         """
         Read the tiers contained in the Praat-formated TextGrid file
@@ -718,7 +718,7 @@ class TextGrid(object):
                     source.readline().rstrip().split() # header junk
                     jmin = round(float(source.readline().rstrip().split()[2]), 5)
                     jmax = round(float(source.readline().rstrip().split()[2]), 5)
-                    jmrk = self._getMark(source)
+                    jmrk = _getMark(source)
                     if jmin < jmax: # non-null
                         itie.addInterval(Interval(jmin, jmax, jmrk))
                 self.append(itie)

--- a/textgrid/textgrid.py
+++ b/textgrid/textgrid.py
@@ -51,8 +51,10 @@ def _getMark(text):
                       re.DOTALL)
         if m != None:
             break
-    return m.groups()[2][1:-1]
+    return m.groups()[2][1:-1].replace('""', '"')
 
+def _formatMark(text):
+    return text.replace('"', '""')
 
 def readFile(f):
     """
@@ -370,8 +372,8 @@ class PointTier(object):
         for i in range(int(source.readline().rstrip().split()[3])):
             source.readline().rstrip() # header
             itim = float(source.readline().rstrip().split()[2])
-            imrk = source.readline().rstrip().split()[2].replace('"', '')
-            self.points.append(Point(imrk, itim))
+            imrk = _getMark(source)
+            self.points.append(Point(itim, imrk))
 
     def write(self, f):
         """
@@ -384,12 +386,14 @@ class PointTier(object):
         print('Object class = "TextTier"\n', file=sink)
 
         print('xmin = {0}'.format(self.minTime), file=sink)
-        print('xmax = {0}'.format(self.maxTime), file=sink)
+        print('xmax = {0}'.format(self.maxTime if self.maxTime \
+                                          else self.points[-1].time),file=sink)
         print('points: size = {0}'.format(len(self)), file=sink)
         for (i, point) in enumerate(self.points, 1):
             print('points [{0}]:'.format(i), file=sink)
             print('\ttime = {0}'.format(point.time), file=sink)
-            print('\tmark = {0}'.format(point.mark), file=sink)
+            mark = _formatMark(point.mark)
+            print('\tmark = "{0}"'.format(mark), file=sink)
         sink.close()
 
     def bounds(self):
@@ -519,7 +523,7 @@ class IntervalTier(object):
             source.readline().rstrip() # header
             imin = float(source.readline().rstrip().split()[2])
             imax = float(source.readline().rstrip().split()[2])
-            imrk = source.readline().rstrip().split()[2].replace('"', '')
+            imrk = _getMark(source)
             self.intervals.append(Interval(imin, imax, imrk))
         source.close()
 
@@ -559,7 +563,8 @@ class IntervalTier(object):
             print('intervals [{0}]'.format(i),file=sink)
             print('\txmin = {0}'.format(interval.minTime),file=sink)
             print('\txmax = {0}'.format(interval.maxTime),file=sink)
-            print('\ttext = "{0}"'.format(interval.mark),file=sink)
+            mark = _formatMark(interval.mark)
+            print('\ttext = "{0}"'.format(mark),file=sink)
         sink.close()
 
     def bounds(self):
@@ -714,7 +719,7 @@ class TextGrid(object):
                     source.readline().rstrip() # header junk
                     jtim = round(float(source.readline().rstrip().split()[2]),
                                                                            5)
-                    jmrk = source.readline().rstrip().split()[2][1:-1]
+                    jmrk = _getMark(source)
                     itie.addPoint(Point(jtim, jmrk))
                 self.append(itie)
         source.close()
@@ -755,8 +760,8 @@ class TextGrid(object):
                                                         interval.minTime),file=sink)
                     print('\t\t\t\txmax = {0}'.format(
                                                         interval.maxTime),file=sink)
-                    print('\t\t\t\ttext = "{0}"'.format(
-                                                        interval.mark),file=sink)
+                    mark = _formatMark(interval.mark)
+                    print('\t\t\t\ttext = "{0}"'.format(mark),file=sink)
             elif tier.__class__ == PointTier: # PointTier
                 print('\t\tclass = "TextTier"',file=sink)
                 print('\t\tname = "{0}"'.format(tier.name),file=sink)
@@ -766,8 +771,8 @@ class TextGrid(object):
                 for (k, point) in enumerate(tier, 1):
                     print('\t\t\tpoints [{0}]:'.format(k),file=sink)
                     print('\t\t\t\ttime = {0}'.format(point.time),file=sink)
-                    print('\t\t\t\tmark = "{0}"'.format(
-                                                           point.mark),file=sink)
+                    mark = _formatMark(point.mark)
+                    print('\t\t\t\tmark = "{0}"'.format(mark),file=sink)
         sink.close()
 
     # alternative constructor

--- a/textgrid/textgrid.py
+++ b/textgrid/textgrid.py
@@ -334,12 +334,6 @@ class PointTier(object):
     def __getitem__(self, i):
         return self.points[i]
 
-    def __min__(self):
-        return self.minTime
-
-    def __max__(self):
-        return self.maxTime
-
     def add(self, time, mark):
         """
         constructs a Point and adds it to the PointTier, maintaining order
@@ -387,10 +381,10 @@ class PointTier(object):
         """
         sink = f if hasattr(f, 'write') else codecs.open(f, 'w', 'UTF-8')
         print('File type = "ooTextFile"', file=sink)
-        print('Object class = "TextTier"', file=sink)
+        print('Object class = "TextTier"\n', file=sink)
 
-        print('xmin = {0}'.format(min(self)), file=sink)
-        print('xmax = {0}'.format(max(self)), file=sink)
+        print('xmin = {0}'.format(self.minTime), file=sink)
+        print('xmax = {0}'.format(self.maxTime), file=sink)
         print('points: size = {0}'.format(len(self)), file=sink)
         for (i, point) in enumerate(self.points, 1):
             print('points [{0}]:'.format(i), file=sink)
@@ -470,12 +464,6 @@ class IntervalTier(object):
 
     def __getitem__(self, i):
         return self.intervals[i]
-
-    def __min__(self):
-        return self.minTime
-
-    def __max__(self):
-        return self.maxTime
 
     def add(self, minTime, maxTime, mark):
         self.addInterval(Interval(minTime, maxTime, mark))
@@ -671,12 +659,6 @@ class TextGrid(object):
         """
         return [tier.name for tier in self.tiers]
 
-    def __min__(self):
-        return self.minTime
-
-    def __max__(self):
-        return self.maxTime
-
     def append(self, tier):
         if self.maxTime is not None and tier.maxTime is not None and tier.maxTime > self.maxTime:
             raise ValueError(self.maxTime) # too late
@@ -778,8 +760,8 @@ class TextGrid(object):
             elif tier.__class__ == PointTier: # PointTier
                 print('\t\tclass = "TextTier"',file=sink)
                 print('\t\tname = "{0}"'.format(tier.name),file=sink)
-                print('\t\txmin = {0}'.format(min(tier)),file=sink)
-                print('\t\txmax = {0}'.format(max(tier)),file=sink)
+                print('\t\txmin = {0}'.format(tier.minTime),file=sink)
+                print('\t\txmax = {0}'.format(maxT),file=sink)
                 print('\t\tpoints: size = {0}'.format(len(tier)),file=sink)
                 for (k, point) in enumerate(tier, 1):
                     print('\t\t\tpoints [{0}]:'.format(k),file=sink)


### PR DESCRIPTION
 * `PointTier.read` was passing arguments to `Point` in the wrong order
 * `TextGrid.write` was using `min()` and `max()` to get xmin and xmax for tiers, except for IntervalTiers, which returns an object rather than a string (see #7), so writing a textgrid with a PointTier didn't create a valid file. and the same issue for `PointTier.write`
 * remove `__min__` and `__max__` in re #7
 * `PointTier.write` missed a newline after writing the `Object class` line
 * double-quotes in mark or text fields need to be doubled when writing, or Praat can't read the written textgrids
 * doubled double-quotes in textgrids written from Praat need to be reduced to single double-quotes
 * add tests that cover the above. Passes for me with 2.7, passes with ResourceWarnings with 3.4 for unclosed files from `readFile` which can be refactored separately