### PR TITLE
Prevent creation of intervals with minTime == maxTime

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -372,6 +372,8 @@ class TestIntervalTier(unittest.TestCase):
         self.foo.add(2.0, 2.5, 'baz')
         
         self.assertEqual(repr(self.foo), 'IntervalTier(foo, [Interval(0.0, 2.0, bar), Interval(2.0, 2.5, baz)])')
+
+        self.assertRaises(ValueError, self.foo.add, 2.5, 2.5, 'bar')
         
     def test_remove(self):
         self.foo.add(0.0, 2.0, 'bar')

--- a/textgrid/textgrid.py
+++ b/textgrid/textgrid.py
@@ -170,7 +170,7 @@ class Interval(object):
     """
 
     def __init__(self, minTime, maxTime, mark):
-        if minTime > maxTime: # not an actual interval
+        if minTime >= maxTime: # not an actual interval
             raise ValueError(minTime, maxTime)
         self.minTime = minTime
         self.maxTime = maxTime

--- a/textgrid/textgrid.py
+++ b/textgrid/textgrid.py
@@ -170,7 +170,8 @@ class Interval(object):
     """
 
     def __init__(self, minTime, maxTime, mark):
-        if minTime >= maxTime: # not an actual interval
+        if minTime >= maxTime:
+            # Praat does not support intervals with duration <= 0
             raise ValueError(minTime, maxTime)
         self.minTime = minTime
         self.maxTime = maxTime


### PR DESCRIPTION
Addresses #15 