### PR TITLE
Allowed intervalContaining to work if the index is 0

### DIFF
--- a/textgrid/textgrid.py
+++ b/textgrid/textgrid.py
@@ -467,7 +467,7 @@ class IntervalTier(object):
         can be a numeric type, or a Point object.
         """
         i = self.indexContaining(time)
-        if i:
+        if i is not None:
             return self.intervals[i]
 
     def read(self, f, round_digits=DEFAULT_TEXTGRID_PRECISION):


### PR DESCRIPTION
Fixed issue #22 by switching `if i:` to `if i is not None:`