### PR TITLE
add 'encoding' keyword to TextGrid.read, fixes #27

### DIFF
--- a/textgrid/textgrid.py
+++ b/textgrid/textgrid.py
@@ -658,12 +658,13 @@ class TextGrid(object):
         """
         return (self.tiers.pop(i) if i else self.tiers.pop())
 
-    def read(self, f, round_digits=DEFAULT_TEXTGRID_PRECISION):
+    def read(self, f, round_digits=DEFAULT_TEXTGRID_PRECISION, encoding=None):
         """
         Read the tiers contained in the Praat-formatted TextGrid file
         indicated by string f. Times are rounded to the specified precision.
         """
-        encoding = detectEncoding(f)
+        if encoding is None:
+            encoding = detectEncoding(f)
         with codecs.open(f, 'r', encoding=encoding) as source:
             file_type, short = parse_header(source)
             if file_type != 'TextGrid':


### PR DESCRIPTION
I added it to `TextGrid.read` instead of `TextGrid` (which I suggested earlier), since I thought later control would be better. I added it to the end of the arguments for backwards compatibility.