### PR TITLE
Add overlap warnings when strict is False

### DIFF
--- a/textgrid/textgrid.py
+++ b/textgrid/textgrid.py
@@ -32,6 +32,7 @@ from __future__ import print_function
 import re
 import codecs
 import os.path
+import logging
 
 from sys import stderr
 from bisect import bisect_left
@@ -206,7 +207,7 @@ class Interval(object):
             if self.strict and self.overlaps(other):
                 raise (ValueError(self, other))
             elif self.overlaps(other):
-                print("Overlap for interval: {} {}".format(self.mark,
+                logging.warning("Overlap for interval: {} {}".format(self.mark,
                             (float(self.minTime), float(self.maxTime))))
                 return self.minTime < other.minTime
             return self.minTime < other.minTime
@@ -220,7 +221,7 @@ class Interval(object):
             if self.strict and self.overlaps(other):
                 raise (ValueError(self, other))
             elif self.overlaps(other):
-                print("Overlap for interval: {} {}".format(self.mark,
+                logging.warning("Overlap for interval: {} {}".format(self.mark,
                             (float(self.minTime), float(self.maxTime))))
                 return self.minTime < other.minTime
             return self.maxTime > other.maxTime
@@ -242,7 +243,7 @@ class Interval(object):
                 # this returns the two intervals, so user can patch things
                 # up if s/he so chooses
             elif self.overlaps(other):
-                print("Overlap for interval: {} {}".format(self.mark,
+                logging.warning("Overlap for interval: {} {}".format(self.mark,
                             (float(self.minTime), float(self.maxTime))))
                 return cmp(self.minTime, other.minTime)
             return cmp(self.minTime, other.minTime)

--- a/textgrid/textgrid.py
+++ b/textgrid/textgrid.py
@@ -207,8 +207,8 @@ class Interval(object):
             if self.strict and self.overlaps(other):
                 raise (ValueError(self, other))
             elif self.overlaps(other):
-                logging.warning("Overlap for interval: {} {}".format(self.mark,
-                            (float(self.minTime), float(self.maxTime))))
+                logging.warning("Overlap for interval %s: (%f, %f)",
+                    self.mark, self.minTime, self.maxTime)
                 return self.minTime < other.minTime
             return self.minTime < other.minTime
         elif hasattr(other, 'time'):
@@ -221,8 +221,8 @@ class Interval(object):
             if self.strict and self.overlaps(other):
                 raise (ValueError(self, other))
             elif self.overlaps(other):
-                logging.warning("Overlap for interval: {} {}".format(self.mark,
-                            (float(self.minTime), float(self.maxTime))))
+                logging.warning("Overlap for interval %s: (%f, %f)",
+                    self.mark, self.minTime, self.maxTime)
                 return self.minTime < other.minTime
             return self.maxTime > other.maxTime
         elif hasattr(other, 'time'):
@@ -243,8 +243,8 @@ class Interval(object):
                 # this returns the two intervals, so user can patch things
                 # up if s/he so chooses
             elif self.overlaps(other):
-                logging.warning("Overlap for interval: {} {}".format(self.mark,
-                            (float(self.minTime), float(self.maxTime))))
+                logging.warning("Overlap for interval %s: (%f, %f)",
+                    self.mark, self.minTime, self.maxTime)
                 return cmp(self.minTime, other.minTime)
             return cmp(self.minTime, other.minTime)
         elif hasattr(other, 'time'):  # comparing Intervals and Points

--- a/textgrid/textgrid.py
+++ b/textgrid/textgrid.py
@@ -205,6 +205,10 @@ class Interval(object):
         if hasattr(other, 'minTime'):
             if self.strict and self.overlaps(other):
                 raise (ValueError(self, other))
+            elif self.overlaps(other):
+                print("Overlap for interval: {} {}".format(self.mark,
+                            (float(self.minTime), float(self.maxTime))))
+                return self.minTime < other.minTime
             return self.minTime < other.minTime
         elif hasattr(other, 'time'):
             return self.maxTime < other.time
@@ -215,6 +219,10 @@ class Interval(object):
         if hasattr(other, 'maxTime'):
             if self.strict and self.overlaps(other):
                 raise (ValueError(self, other))
+            elif self.overlaps(other):
+                print("Overlap for interval: {} {}".format(self.mark,
+                            (float(self.minTime), float(self.maxTime))))
+                return self.minTime < other.minTime
             return self.maxTime > other.maxTime
         elif hasattr(other, 'time'):
             return self.minTime > other.time
@@ -229,10 +237,14 @@ class Interval(object):
 
     def __cmp__(self, other):
         if hasattr(other, 'minTime') and hasattr(other, 'maxTime'):
-            if self.overlaps(other):
+            if self.strict and self.overlaps(other):
                 raise ValueError(self, other)
                 # this returns the two intervals, so user can patch things
                 # up if s/he so chooses
+            elif self.overlaps(other):
+                print("Overlap for interval: {} {}".format(self.mark,
+                            (float(self.minTime), float(self.maxTime))))
+                return cmp(self.minTime, other.minTime)
             return cmp(self.minTime, other.minTime)
         elif hasattr(other, 'time'):  # comparing Intervals and Points
             return cmp(self.minTime, other.time) + \


### PR DESCRIPTION
Currently there is not a way to see all erroneous intervals in a TextGrid, even when `strict` is set to `False`. Here, if `strict = False`, the mark and start/end times of an interval will be printed, allowing a user to collect all problematic instances without crashing on the first case.