### PR TITLE
Object Comparison methods

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='TextGrid',
-    version='1.5',
+    version='1.6',
     author='Kyle Gorman et al.',
     author_email='kylebgorman@gmail.com',
     packages=['textgrid'],

--- a/tests.py
+++ b/tests.py
@@ -398,6 +398,47 @@ class TestIntervalTierComparison(unittest.TestCase):
         self.assertNotEqual(self.foo, self.baz)
 
 
+class TestTextGridComparison(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        foo_point = textgrid.textgrid.Point(3.0, 'foo')
+        bar_interval = textgrid.textgrid.Interval(3.0, 5.0, 'bar')
+        baz_interval = textgrid.textgrid.Interval(5.0, 6.0, 'baz')
+
+        cls.foo_tier = textgrid.textgrid.PointTier()
+        bar_tier = textgrid.textgrid.IntervalTier()
+        baz_tier = textgrid.textgrid.IntervalTier()
+        bat_tier = textgrid.textgrid.IntervalTier()
+
+        cls.foo_tier.addPoint(foo_point)
+        bar_tier.addInterval(bar_interval)
+        baz_tier.addInterval(baz_interval)
+        bat_tier.addInterval(baz_interval)
+
+        cls.foo_grid = textgrid.textgrid.TextGrid()
+        cls.bar_grid = textgrid.textgrid.TextGrid()
+        cls.baz_grid = textgrid.textgrid.TextGrid()
+        cls.bat_grid = textgrid.textgrid.TextGrid()
+
+        cls.foo_grid.append(cls.foo_tier)
+        cls.bar_grid.append(bar_tier)
+        cls.baz_grid.append(baz_tier)
+        cls.bat_grid.append(bat_tier)
+
+    def test_textgrid_equal(self):
+        self.assertEqual(self.baz_grid, self.bat_grid)
+
+    def test_textgrid_unequal_different_intervals(self):
+        self.assertNotEqual(self.bar_grid, self.baz_grid)
+
+    def test_textgrid_unequal_different_tier_types(self):
+        self.assertNotEqual(self.foo_grid, self.bar_grid)
+
+    def test_type_unequal(self):
+        self.assertNotEqual(self.foo_tier, self.foo_grid)
+
+
 class TestPointTier(unittest.TestCase):
 
     def setUp(self):

--- a/tests.py
+++ b/tests.py
@@ -342,6 +342,62 @@ class TestIntervalComparison(unittest.TestCase):
         self.assertIn(4.0, self.baz)
 
 
+class TestPointTierComparison(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        foo_point = textgrid.textgrid.Point(3.0, 'foo')
+        bar_point = textgrid.textgrid.Point(4.0, 'bar')
+        baz_interval = textgrid.textgrid.Interval(3.0, 5.0, 'baz')
+
+        cls.foo = textgrid.textgrid.PointTier()
+        cls.bar = textgrid.textgrid.PointTier()
+        cls.bam = textgrid.textgrid.PointTier()
+        cls.baz = textgrid.textgrid.IntervalTier()
+
+        cls.foo.addPoint(foo_point)
+        cls.bar.addPoint(bar_point)
+        cls.bam.addPoint(bar_point)
+        cls.baz.addInterval(baz_interval)
+
+    def test_point_equal(self):
+        self.assertEqual(self.bar, self.bam)
+
+    def test_point_unequal(self):
+        self.assertNotEqual(self.foo, self.bar)
+
+    def test_type_unequal(self):
+        self.assertNotEqual(self.foo, self.baz)
+
+
+class TestIntervalTierComparison(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        foo_point = textgrid.textgrid.Point(3.0, 'foo')
+        baz_interval = textgrid.textgrid.Interval(3.0, 5.0, 'baz')
+        bat_interval = textgrid.textgrid.Interval(5.0, 6.0, 'bar')
+
+        cls.foo = textgrid.textgrid.PointTier()
+        cls.bar = textgrid.textgrid.IntervalTier()
+        cls.baz = textgrid.textgrid.IntervalTier()
+        cls.bat = textgrid.textgrid.IntervalTier()
+
+        cls.foo.addPoint(foo_point)
+        cls.bar.addInterval(baz_interval)
+        cls.baz.addInterval(baz_interval)
+        cls.bat.addInterval(bat_interval)
+
+    def test_interval_equal(self):
+        self.assertEqual(self.bar, self.baz)
+
+    def test_interval_unequal(self):
+        self.assertNotEqual(self.baz, self.bat)
+
+    def test_type_unequal(self):
+        self.assertNotEqual(self.foo, self.baz)
+
+
 class TestPointTier(unittest.TestCase):
 
     def setUp(self):
@@ -448,6 +504,7 @@ class TestTextGrid(unittest.TestCase):
 
     def test_get_names(self):
         self.assertListEqual(self.foo.getNames(), ['bar', 'baz', 'bar'])
+
 
 class TestReadTextGrid(unittest.TestCase):
     @classmethod

--- a/textgrid/textgrid.py
+++ b/textgrid/textgrid.py
@@ -622,6 +622,14 @@ class TextGrid(object):
         self.tiers = []
         self.strict = strict
 
+    def __eq__(self, other):
+        if not hasattr(other, 'tiers'):
+            return False
+        elif all(a == b for a, b in zip(other.tiers, self.tiers)):
+            return True
+        else:
+            return False
+
     def __str__(self):
         return '<TextGrid {0}, {1} Tiers>'.format(self.name, len(self))
 

--- a/textgrid/textgrid.py
+++ b/textgrid/textgrid.py
@@ -297,7 +297,7 @@ class Interval(object):
             return self.minTime <= other <= self.maxTime
 
     def bounds(self):
-        return self.minTime, self.maxTime
+        return (self.minTime, self.maxTime)
 
 
 class PointTier(object):
@@ -317,10 +317,8 @@ class PointTier(object):
     def __eq__(self, other):
         if not hasattr(other, 'points'):
             return False
-        elif all(a == b for a, b in zip(other.points, self.points)):
-            return True
         else:
-            return False
+            return all([a == b for a, b in zip(self.points, other.points)])
 
     def __str__(self):
         return '<PointTier {0}, {1} points>'.format(self.name, len(self))
@@ -404,7 +402,7 @@ class PointTier(object):
         sink.close()
 
     def bounds(self):
-        return self.minTime, self.maxTime or self.points[-1].time
+        return (self.minTime, self.maxTime or self.points[-1].time)
 
     # alternative constructor
 
@@ -433,10 +431,8 @@ class IntervalTier(object):
     def __eq__(self, other):
         if not hasattr(other, 'intervals'):
             return False
-        elif all(a == b for a, b in zip(other.intervals, self.intervals)):
-            return True
         else:
-            return False
+            return all([a == b for a, b in zip(self.intervals, other.intervals)])
 
     def __str__(self):
         return '<IntervalTier {0}, {1} intervals>'.format(self.name,
@@ -561,7 +557,7 @@ class IntervalTier(object):
         sink.close()
 
     def bounds(self):
-        return self.minTime, self.maxTime or self.intervals[-1].maxTime
+        return (self.minTime, self.maxTime or self.intervals[-1].maxTime)
 
     # alternative constructor
 
@@ -595,7 +591,7 @@ def parse_header(source):
     short = 'short' in m.groups()[0]
     file_type = parse_line(source.readline(), short, '')  # header junk
     t = source.readline()  # header junk
-    return file_type, short
+    return (file_type, short)
 
 
 class TextGrid(object):
@@ -625,10 +621,8 @@ class TextGrid(object):
     def __eq__(self, other):
         if not hasattr(other, 'tiers'):
             return False
-        elif all(a == b for a, b in zip(other.tiers, self.tiers)):
-            return True
         else:
-            return False
+            return all([a == b for a, b in zip(self.tiers, other.tiers)])
 
     def __str__(self):
         return '<TextGrid {0}, {1} Tiers>'.format(self.name, len(self))
@@ -693,7 +687,7 @@ class TextGrid(object):
         Remove and return tier at index i (default last). Will raise
         IndexError if TextGrid is empty or index is out of range.
         """
-        return self.tiers.pop(i) if i else self.tiers.pop()
+        return (self.tiers.pop(i) if i else self.tiers.pop())
 
     def read(self, f, round_digits=DEFAULT_TEXTGRID_PRECISION, encoding=None):
         """

--- a/textgrid/textgrid.py
+++ b/textgrid/textgrid.py
@@ -208,7 +208,7 @@ class Interval(object):
                 raise (ValueError(self, other))
             elif self.overlaps(other):
                 logging.warning("Overlap for interval %s: (%f, %f)",
-                    self.mark, self.minTime, self.maxTime)
+                                self.mark, self.minTime, self.maxTime)
                 return self.minTime < other.minTime
             return self.minTime < other.minTime
         elif hasattr(other, 'time'):
@@ -222,7 +222,7 @@ class Interval(object):
                 raise (ValueError(self, other))
             elif self.overlaps(other):
                 logging.warning("Overlap for interval %s: (%f, %f)",
-                    self.mark, self.minTime, self.maxTime)
+                                self.mark, self.minTime, self.maxTime)
                 return self.minTime < other.minTime
             return self.maxTime > other.maxTime
         elif hasattr(other, 'time'):
@@ -244,7 +244,7 @@ class Interval(object):
                 # up if s/he so chooses
             elif self.overlaps(other):
                 logging.warning("Overlap for interval %s: (%f, %f)",
-                    self.mark, self.minTime, self.maxTime)
+                                self.mark, self.minTime, self.maxTime)
                 return cmp(self.minTime, other.minTime)
             return cmp(self.minTime, other.minTime)
         elif hasattr(other, 'time'):  # comparing Intervals and Points
@@ -297,7 +297,7 @@ class Interval(object):
             return self.minTime <= other <= self.maxTime
 
     def bounds(self):
-        return (self.minTime, self.maxTime)
+        return self.minTime, self.maxTime
 
 
 class PointTier(object):
@@ -313,6 +313,14 @@ class PointTier(object):
         self.minTime = minTime
         self.maxTime = maxTime
         self.points = []
+
+    def __eq__(self, other):
+        if not hasattr(other, 'points'):
+            return False
+        elif all(a == b for a, b in zip(other.points, self.points)):
+            return True
+        else:
+            return False
 
     def __str__(self):
         return '<PointTier {0}, {1} points>'.format(self.name, len(self))
@@ -396,7 +404,7 @@ class PointTier(object):
         sink.close()
 
     def bounds(self):
-        return (self.minTime, self.maxTime or self.points[-1].time)
+        return self.minTime, self.maxTime or self.points[-1].time
 
     # alternative constructor
 
@@ -421,6 +429,14 @@ class IntervalTier(object):
         self.maxTime = maxTime
         self.intervals = []
         self.strict = True
+
+    def __eq__(self, other):
+        if not hasattr(other, 'intervals'):
+            return False
+        elif all(a == b for a, b in zip(other.intervals, self.intervals)):
+            return True
+        else:
+            return False
 
     def __str__(self):
         return '<IntervalTier {0}, {1} intervals>'.format(self.name,
@@ -669,7 +685,7 @@ class TextGrid(object):
         Remove and return tier at index i (default last). Will raise
         IndexError if TextGrid is empty or index is out of range.
         """
-        return (self.tiers.pop(i) if i else self.tiers.pop())
+        return self.tiers.pop(i) if i else self.tiers.pop()
 
     def read(self, f, round_digits=DEFAULT_TEXTGRID_PRECISION, encoding=None):
         """


### PR DESCRIPTION
I added __eq__ methods to the tiers and textgrid object in order to facilitate unit test construction for projects that incorporate textgrids. For example, projects that have read and write methods for textgrids for both the native .TextGrid format and for writing as .csv, can now test that reading in one format and writing in another produce the expected results. Unit tests are included.