### PR TITLE
Update textgrid.py

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -497,6 +497,7 @@ class TestIntervalTier(unittest.TestCase):
         self.foo.add(2.0, 2.5, 'baz')
         
         self.assertEqual(repr(self.foo.intervalContaining(2.25)), 'Interval(2.0, 2.5, baz)')
+        self.assertEqual(repr(self.foo.intervalContaining(0.5)), 'Interval(0.0, 1.0, bar)')
 
     def test_add_too_late(self):
         foo = textgrid.textgrid.IntervalTier('foo', maxTime=3.5)

--- a/textgrid/textgrid.py
+++ b/textgrid/textgrid.py
@@ -492,7 +492,7 @@ class IntervalTier(object):
         can be a numeric type, or a Point object.
         """
         i = self.indexContaining(time)
-        if i:
+        if i is not None:
             return self.intervals[i]
 
     def read(self, f, round_digits=DEFAULT_TEXTGRID_PRECISION):


### PR DESCRIPTION
Changed logic in `IntervalTier.intervalContaining()` so that you can check for times that are less than 1 without returning None.

Suppose `mygrid` is a TextGrid with a duration of greater than 0.1 seconds. `mygrid[0].intervalContaining(0.1)` would previously return `None`. It seems `0.1` is somehow evaluating to `False`

Addresses issue #38 